### PR TITLE
Fix api whitelist wildcard

### DIFF
--- a/services/api.service.js
+++ b/services/api.service.js
@@ -21,7 +21,7 @@ class ApiService extends Service {
 
             authorization: true,
 
-            whitelist: ['*'],
+            whitelist: ['**'],
 
             aliases: {
               'POST login': 'auth.login',


### PR DESCRIPTION
The whitelist wildcard config for allowing all requests is '**'.