### PR TITLE
Add route for registering user accounts and authentication examples

### DIFF
--- a/services/api.service.js
+++ b/services/api.service.js
@@ -25,6 +25,7 @@ class ApiService extends Service {
 
             aliases: {
               'POST login': 'auth.login',
+              'POST register': 'auth.register',
 
               // The user service aliases are defined explicitely v.s. 'REST' as the username is used
               // for operations and not the id directly. These actions delegate to the underlying database

--- a/test/requests/register-user.json
+++ b/test/requests/register-user.json
@@ -1,0 +1,7 @@
+{
+  "user": {
+    "username": "bob",
+    "password": "secret-password",
+    "email": "bob@example.com"
+  }
+}


### PR DESCRIPTION
Provide documentation on authenticating users and using the JWT from
the response to make API calls that require an authorization header and token.