### PR TITLE
Expose Slack service to API gateway

### DIFF
--- a/docker-compose.example.env
+++ b/docker-compose.example.env
@@ -22,10 +22,11 @@ INVENTORY_TOPIC=inventory
 ORDERS_BOOTSTRAP_SERVER=kafka:29092
 ORDERS_TOPIC=orders
 
-SLACK_BOOTSTRAP_SERVER=kafka:29092
 SLACK_WEBHOOK_URI=https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/xxxxxxxxxxxx
 SLACK_CHANNEL=#general
 SLACK_USERNAME=slack_service
+SLACK_BOOTSTRAP_SERVER=kafka:29092
+SLACK_KAFKA_TOPIC=slack-notifications
 
 SMTP_USER=xxxxxxxxm@ethereal.email
 SMTP_PASS=xxxxxxxxx

--- a/services/api.service.js
+++ b/services/api.service.js
@@ -27,7 +27,7 @@ class ApiService extends Service {
               'POST login': 'auth.login',
               'POST register': 'auth.register',
 
-              // The user service aliases are defined explicitely v.s. 'REST' as the username is used
+              // The user service aliases are defined explicitly vs 'REST' as the username is used
               // for operations and not the id directly. These actions delegate to the underlying database
               // mixin actions after the id for the user associated with the username has been retrieved.
               'GET users': 'users.list',
@@ -40,6 +40,9 @@ class ApiService extends Service {
 
               'REST orders': 'orders',
             },
+
+            // Allow services to directly declare their routes
+            autoAliases: true,
           },
         ],
 

--- a/services/slack.service.js
+++ b/services/slack.service.js
@@ -20,13 +20,14 @@ class SlackService extends Service {
         username: process.env.SLACK_USERNAME || 'slack_service',
         bootstrapServer: process.env.SLACK_BOOTSTRAP_SERVER || 'localhost:9092',
         kafkaTopic: process.env.SLACK_KAFKA_TOPIC || 'slack-notifications',
+
+        // Base request route path
+        rest: 'slack/',
       },
 
       actions: {
-        send: {
-          params: {
-            message: 'string',
-          },
+        create: {
+          rest: 'POST /',
           handler: this.send,
         },
       },
@@ -143,9 +144,9 @@ class SlackService extends Service {
     );
 
     this.consumer.on('message', (message) => {
-      // csonst buf = new Buffer(message.value, 'binary'), // Read string into a buffer.
+      // const buf = new Buffer(message.value, 'binary'), // Read string into a buffer.
       // decodedMessage = type.fromBuffer(buf.slice(0)); // Skip prefix.
-      // this.logger.info(decodedMessage);
+      // this.logger.debug(decodedMessage);
 
       this.logger.debug(message);
 


### PR DESCRIPTION
The Slack service exposes its message sending endpoint using HTTP POST via the Moleculer Web API gateway.

Additional documentation provided on invoking this service by publishing messages to a Kafka topic.