### PR TITLE
Use event information as content of resolved promise

### DIFF
--- a/services/inventory.service.js
+++ b/services/inventory.service.js
@@ -192,7 +192,7 @@ class InventoryService extends Service {
             reject(error);
           } else {
             this.logger.debug('Result:', result);
-            resolve(result);
+            resolve({ eventType, item });
           }
         },
       );

--- a/services/orders.service.js
+++ b/services/orders.service.js
@@ -161,13 +161,13 @@ class OrdersService extends Service {
 
       this.sendMessage(
         this.settings.ordersTopic,
-        { key: order.product, value: JSON.stringify({ order, eventType }) },
+        { key: order.product, value: JSON.stringify({ eventType, order }) },
         (error, result) => {
           if (error) {
             reject(error);
           } else {
             this.logger.debug('Result:', result);
-            resolve(result);
+            resolve({ eventType, order });
           }
         },
       );

--- a/services/users.service.js
+++ b/services/users.service.js
@@ -220,7 +220,7 @@ class UsersService extends Service {
             reject(error);
           } else {
             this.logger.debug('Result:', result);
-            resolve(result);
+            resolve(data);
           }
         },
       );


### PR DESCRIPTION
The promise that is resolved when the event is successfully sent
to Kafka now contains the actual event type and information. This previously
returned, and was the body of the HTTP response, the Kafka partition
and offset number which held no meaning.