### PR TITLE
Emit events to Moleculer services for stock availability

### DIFF
--- a/services/inventory.service.js
+++ b/services/inventory.service.js
@@ -92,6 +92,9 @@ class InventoryService extends Service {
       .then(() => this.getQuantity(ctx, product, true))
       .then((available) => {
         if (quantity > available) {
+          // Emit an event that there is no further stock available
+          this.broker.emit('inventory.insufficientStock', { product });
+
           return this.Promise.reject(
             new MoleculerError(
               `Not enough items available in inventory for product '${product}'.`,

--- a/services/slack.service.js
+++ b/services/slack.service.js
@@ -30,12 +30,16 @@ class SlackService extends Service {
       actions: {
         create: {
           rest: 'POST /',
-          handler: this.postChatMessage,
+          handler: this.send,
         },
       },
 
       events: {
-        // No events
+        'inventory.insufficientStock': {
+          handler(ctx) {
+            this.postChatMessage(`Insufficient Stock: ${ctx.params.product}`);
+          },
+        },
       },
 
       created: this.serviceCreated,
@@ -49,7 +53,6 @@ class SlackService extends Service {
     this.postChatMessage(ctx.params.message);
   }
 
-  // Private method
   postChatMessage(message) {
     this.logger.debug(
       `Posting message '${message}' to Slack channel ${this.settings.channel}`,


### PR DESCRIPTION
The inventory service emits Moleculer events for other services to subscribe to
to be notified when insufficient stock is available while processing an order.

The Slack service handles this event and sends the insufficient stock message
to a channel.

Additional fix for incorrect action handler.