### PR TITLE
Include service name in consumer group id

### DIFF
--- a/mixins/kafka.mixin.js
+++ b/mixins/kafka.mixin.js
@@ -72,7 +72,9 @@ module.exports = {
         kafkaHost: bootstrapServer, // connect directly to kafka broker (instantiates a KafkaClient)
         batch: undefined, // put client batch settings if you need them (see Client)
         // ssl: true, // optional (defaults to false) or tls options hash
-        groupId: `moleculer-${topic}`,
+        // The consumer group id consists of the prefix 'moleculer-', the name of the service that
+        // this mixin is being merged into, and the topic being consumed.
+        groupId: `moleculer-${this.name}-${topic}`,
         sessionTimeout: 15000,
         // An array of partition assignment protocols ordered by preference.
         // 'roundrobin' or 'range' string for built ins (see below to pass in custom assignment protocol)


### PR DESCRIPTION
The Kafka consumer group id includes the name of the service that the
mixin is being merged into.
This means that the consumer groups are unique per service so that
multiple services can consume messages from the same Kafka topic.