### PR TITLE
Add customer Id to user accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 This project is a number of microservices built in Node.js using the [Moleculer]
 microservices framework.
 
+The inspiration for this was to learn more about the Moleculer framework and
+build a proof-of-concept based on the Confluent [Building a Microservices
+Ecosystem with Kafka Streams and KSQL] blog. This proof-of-concept is not using
+Kafka Streams or KSQL, but the services are built using event sourcing (with
+Kafka as the messaging platform) with additional patterns and incorporating many
+of the Moleculer features as an example.
+
 This deployment uses Docker containers and consists of the following components:
 
 - [Moleculer] is a the microservices framework for Node.js
@@ -187,16 +194,22 @@ insertion of this item.
 ## Emailer Service
 
 The `Emailer` service sends email messages for order events consumed from a
-Kafka topic.
+Kafka topic. The `OrderCreated` event contains the `customerId` within the
+`order` object, this is used to retrieve the user account associated with that
+identifier and populate the email address.
 
 This deployment uses the online fake SMTP service [Ethereal] for testing the
 sending of emails. Create an account on that site and then set the `SMTP_USER`
 and `SMTP_PASS` to match the account details you are provided.
 
 Run the below command to use the [kafkacat] utility to publish an order event.
+In the example below the customer id of `12345` should be updated with the value
+from your user account. You can get the list of users and their customer
+identifier by making an authenticated API call to the
+<http://moleculer-127-0-0-1.nip.io/api/users> endpoint.
 
 ```sh
-echo '{ "eventType": "OrderCreated", "order": { "product": "Raspberry Pi 4b", "quantity": 1, "price": 145.00, "state": "Pending" } }' \
+echo '{ "eventType": "OrderCreated", "order": { "customerId": 12345, "product": "Raspberry Pi 4b", "quantity": 1, "price": 145.00, "state": "Pending" } }' \
   | kafkacat \
   -P \
   -b localhost:9092 \
@@ -262,6 +275,8 @@ address, which then get forwarded to the actual Kafka broker via the port
 binding in the Docker Compose file. Read the Confluent blog post [Kafka
 Listeners - Explained] for a good explanation, diagrams, and examples of this.
 
+[building a microservices ecosystem with kafka streams and ksql]:
+  https://www.confluent.io/blog/building-a-microservices-ecosystem-with-kafka-streams-and-ksql/
 [confluent]: https://www.confluent.io/
 [ethereal]: https://ethereal.email/
 [httpie]: https://httpie.io/

--- a/services/emailer.service.js
+++ b/services/emailer.service.js
@@ -84,16 +84,19 @@ class EmailerService extends Service {
     });
   }
 
-  processEvent(event) {
+  async processEvent(event) {
     if (event.eventType === 'OrderCreated') {
       this.logger.debug(event);
-      const { product, quantity } = event.order;
+      const { customerId, product, quantity } = event.order;
+      const user = await this.broker.call('users.getUserByCustomerId', {
+        customerId,
+      });
       this.sendEmail({
         from: '"Customer Services" <noreply@example.com>',
-        to: 'bob@example.com',
+        to: user.email,
         subject: `Order: ${product}`,
-        text: `Hi Bob, your order for ${product} is currently being processed.`,
-        html: `Hi Bob,<p>Your order for the below product(s) is currently being processed:<ul><li>${product} <i>(Quantity: ${quantity})</i></li></ul></p>`,
+        text: `Hi ${user.username}, your order for ${product} is currently being processed.`,
+        html: `Hi ${user.username},<p>Your order for the below product(s) is currently being processed:<ul><li>${product} <i>(Quantity: ${quantity})</i></li></ul></p>`,
       });
     }
   }

--- a/test/requests/register-user.json
+++ b/test/requests/register-user.json
@@ -1,6 +1,6 @@
 {
   "user": {
-    "username": "bob",
+    "username": "foo",
     "password": "secret-password",
     "email": "bob@example.com"
   }


### PR DESCRIPTION
A customer identifier number is generated, using the number of milliseconds since the epoch, and
added to the user when their account is created. This customer identifier is used by other services
when retrieving user account information, e.g. associated with customer orders.

Add retrieving users by customer Id:

- Add service action to retrieve users by customer Id
- Add parameter validation to service actions
- Provide single user retrieval function with passed in query filter criteria

Update Emailer service to retrieve user by customer Id and populate email from user account details

Update README instructions to include customerId in order creation example

The http response codes to be returned for client errors for the Users service
are aligned with the recommendations in the Zalando API Guidelines.