### PR TITLE
Define user routes within user service and whitelist

### DIFF
--- a/services/api.service.js
+++ b/services/api.service.js
@@ -21,20 +21,22 @@ class ApiService extends Service {
 
             authorization: true,
 
-            whitelist: ['**'],
+            whitelist: [
+              'auth.login',
+              'auth.register',
+              'users.list',
+              'users.getUser',
+              'users.createUser',
+              'users.updateUser',
+              'users.deleteUser',
+              'slack.create',
+              'inventory.*',
+              'orders.*',
+            ],
 
             aliases: {
               'POST login': 'auth.login',
               'POST register': 'auth.register',
-
-              // The user service aliases are defined explicitly vs 'REST' as the username is used
-              // for operations and not the id directly. These actions delegate to the underlying database
-              // mixin actions after the id for the user associated with the username has been retrieved.
-              'GET users': 'users.list',
-              'GET users/:username': 'users.getUser',
-              'POST users': 'users.createUser',
-              'PUT users/:username': 'users.updateUser',
-              'DELETE users/:username': 'users.deleteUser',
 
               'REST inventory': 'inventory',
 
@@ -43,6 +45,8 @@ class ApiService extends Service {
 
             // Allow services to directly declare their routes
             autoAliases: true,
+            // Only expose routes that have had aliases defined
+            mappingPolicy: 'restrict',
           },
         ],
 


### PR DESCRIPTION
The routes for user operations are declared within the Users service and whitelisted within
the API Gateway. The action handlers do not follow the standard default REST handler names
as they are provided with the username in the path which is used to resolve the actual
database identifier. The default REST action handler names are provided by the DBService
mixin, hence needing to separate these and explicitly declare for the REST HTTP verbs.

Without whitelisting these the usage of the autoAliases setting with a value of true
means that all action handlers were exposed, including the default ones from the database
mixin. This meant that GET /users/:id was calling the database service with 'users.get' and not
'users.getUser' as was expected for the GET /users/:username route