### PR TITLE
Add support for multiple Kafka consumers

### DIFF
--- a/src/services/emailer.service.js
+++ b/src/services/emailer.service.js
@@ -124,10 +124,10 @@ class EmailerService extends Service {
    */
   serviceStarted() {
     // Start the Kafka consumer to read order events for sending emails
-    this.startKafkaConsumer(
-      this.settings.kafka.bootstrapServer,
-      this.settings.kafka.ordersTopic,
-      (error, message) => {
+    this.startKafkaConsumer({
+      bootstrapServer: this.settings.kafka.bootstrapServer,
+      topic: this.settings.kafka.ordersTopic,
+      callback: (error, message) => {
         if (error) {
           this.Promise.reject(
             new MoleculerError(
@@ -139,7 +139,7 @@ class EmailerService extends Service {
         }
         this.processEvent(JSON.parse(message.value));
       },
-    );
+    });
 
     this.logger.debug('Emailer service started.');
   }

--- a/src/services/inventory.service.js
+++ b/src/services/inventory.service.js
@@ -211,10 +211,10 @@ class InventoryService extends Service {
       this.logger.error(error),
     );
 
-    this.startKafkaConsumer(
-      this.settings.bootstrapServer,
-      this.settings.inventoryTopic,
-      (error, message) => {
+    this.startKafkaConsumer({
+      bootstrapServer: this.settings.bootstrapServer,
+      topic: this.settings.inventoryTopic,
+      callback: (error, message) => {
         if (error) {
           this.Promise.reject(
             new MoleculerError(
@@ -226,7 +226,7 @@ class InventoryService extends Service {
         }
         this.processEvent(message.value);
       },
-    );
+    });
 
     this.logger.debug('Inventory service started.');
   }

--- a/src/services/orders.service.js
+++ b/src/services/orders.service.js
@@ -187,10 +187,10 @@ class OrdersService extends Service {
 
     // Start the Kafka consumer to read messages from the topic
     // to be sent to the Slack channel
-    this.startKafkaConsumer(
-      this.settings.bootstrapServer,
-      this.settings.ordersTopic,
-      (error, message) => {
+    this.startKafkaConsumer({
+      bootstrapServer: this.settings.bootstrapServer,
+      topic: this.settings.ordersTopic,
+      callback: (error, message) => {
         if (error) {
           this.Promise.reject(
             new MoleculerError(
@@ -203,7 +203,7 @@ class OrdersService extends Service {
 
         this.processEvent(message.value);
       },
-    );
+    });
 
     this.logger.debug('Orders service started.');
   }

--- a/src/services/slack.service.js
+++ b/src/services/slack.service.js
@@ -129,10 +129,10 @@ class SlackService extends Service {
 
     // Start the Kafka consumer to read messages from the topic
     // to be sent to the Slack channel
-    this.startKafkaConsumer(
-      this.settings.bootstrapServer,
-      this.settings.kafkaTopic,
-      (error, message) => {
+    this.startKafkaConsumer({
+      bootstrapServer: this.settings.bootstrapServer,
+      topic: this.settings.kafkaTopic,
+      callback: (error, message) => {
         if (error) {
           this.Promise.reject(
             new MoleculerError(
@@ -145,7 +145,7 @@ class SlackService extends Service {
 
         this.postChatMessage(message.value);
       },
-    );
+    });
 
     this.logger.debug('Slack service started.');
 


### PR DESCRIPTION
Support has been added to the Kafka service mixin to allow multiple
Kafka consumers to be created by a single service. This provides
the means for services to be able to perform operations based on
events the can consume from multiple topics.

Update services to use Kafka consumer object to supply properties