### PR TITLE
Update to current version of Buster Slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.24.1-buster-slim
+FROM node:current-buster-slim
 
 ENV NODE_ENV=production
 
@@ -7,7 +7,7 @@ WORKDIR /app
 
 COPY package.json .
 
-RUN npm install --production
+RUN npm install --production --ignore-scripts
 
 COPY src/ .
 


### PR DESCRIPTION
* Update Dockerfile to use current version of the Buster Slim image
* IIgnore scripts from running during Production build. This prevents errors
such as build failures due to not being authenticated to Snyk or accessing
Snyk policies.