### PR TITLE
Upgrade to super-linter v4 due to breaking issue

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
super-linter v3 introduced a critical issue "/action/lib/functions/tapLibrary.sh: No such file or directory".
This is resolved in v4 and won't be released in v3.