### PR TITLE
Associate inventory items with an order

### DIFF
--- a/src/services/inventory.service.ts
+++ b/src/services/inventory.service.ts
@@ -39,7 +39,6 @@ class InventoryService extends Service {
       mixins: [DbService, KafkaService],
 
       adapter: new MongooseDbAdapter('mongodb://mongodb:27017/moleculer-db'),
-      fields: ['_id', 'product', 'price', 'state', 'created', 'updated'],
       model: mongoose.model(
         'Product',
         new mongoose.Schema<InventoryItem>({
@@ -78,7 +77,7 @@ class InventoryService extends Service {
             product: 'string',
             quantity: 'number',
           },
-          handler: this.reserveItem,
+          handler: this.reserveItems,
         },
         ship: {
           handler: this.shipItem,
@@ -108,7 +107,7 @@ class InventoryService extends Service {
     });
   }
 
-  async reserveItem(ctx: ContextWithInventory) {
+  async reserveItems(ctx: ContextWithInventory): Promise<InventoryItem[]> {
     const { product, quantity } = ctx.params;
     this.logger.debug('Reserve item:', product, quantity);
 
@@ -137,6 +136,8 @@ class InventoryService extends Service {
         state: InventoryState.RESERVED,
       }),
     );
+
+    return availableItems;
   }
 
   async shipItem(ctx: ContextWithInventory): Promise<any> {

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -32,7 +32,6 @@ class UsersService extends Service {
       mixins: [DbService, KafkaService],
 
       adapter: new MongooseDbAdapter('mongodb://mongodb:27017/moleculer-db'),
-      fields: ['_id', 'username', 'email'],
       model: mongoose.model(
         'User',
         new mongoose.Schema<User>({

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -16,9 +16,10 @@ export enum OrderState {
 export interface Order {
   _id: UUID;
   customerId: UUID;
-  productId: UUID;
-  product: string;
-  quantity: number;
+  items: UUID[];
+  state: OrderState;
+  created?: number;
+  updated?: number;
 }
 
 export interface OrderEvent {


### PR DESCRIPTION
Items are reserved based on their product and each item, based on id,
that has been reserved is added to the order. The "populates" functionality
is used so that when an order is accessed via get/list/find then the inventory
items are populated into the document and not just the array of ids.

Remove redundant "fields" entries as they should be within the "settings" section, but aren't being use to filter out fields anyway.

Use the context to make calls to other services for nested calls and tracing