### PR TITLE
Free reserved items when an order is cancelled

### DIFF
--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -3,6 +3,7 @@ import { UUID } from './types';
 export enum OrderEventType {
   ORDER_CREATED = 'OrderCreated',
   ORDER_UPDATED = 'OrderUpdated',
+  ORDER_CANCELLED = 'OrderCancelled',
 }
 
 export enum OrderState {


### PR DESCRIPTION
The inventory service listens for events on that orders topic and
frees any items associated with an order when it is cancelled.
This releases items that were previously reserved when an order
has been submitted.

This uses the getByIds() helper method provided by the Mongoose
adaptor injected for the DBService mixin to retrieve the items based
on the array of ids contained within the orders document.